### PR TITLE
Final BMS Code from FN 2019

### DIFF
--- a/boards/BMS/bms.c
+++ b/boards/BMS/bms.c
@@ -41,7 +41,10 @@ uint8_t gBMSStatus = 0;
 
 // Timer prescale vars and constants
 uint8_t gCounterTransmit = 0;
-const uint8_t transmit_match = 100;
+const uint8_t transmit_match = 200;
+
+// UART buffer
+char temp_msg[6*20+4+5] = "";
 
 //Under Voltage and Over Voltage Thresholds
 const uint16_t OV_THRESHOLD = 42000;//35900; // Over voltage threshold ADC Code
@@ -129,28 +132,25 @@ uint8_t read_all_voltages(void) // Start Cell ADC Measurement
         }
     }
 
-    // TODO very slow, comment out after inspection ****************************
-    // UART out cell voltages as 10  16-bit ints
-    // char tmp_msg[1+4+4+6*10] = "";
-    // for (int i = 0; i < TOTAL_IC; i++) {
-    //     sprintf(tmp_msg, "v%d,%3d,%u,%u,%u,%u,"
-    //                      "%u,%u,%u,%u,"
-    //                      "%u,%u",
-    //                       i,
-    //                       error,
-    //                       cell_voltages[i][0],
-    //                       cell_voltages[i][1],
-    //                       cell_voltages[i][2],
-    //                       cell_voltages[i][3],
-    //                       cell_voltages[i][4],
-    //                       cell_voltages[i][6],
-    //                       cell_voltages[i][7],
-    //                       cell_voltages[i][8],
-    //                       cell_voltages[i][9],
-    //                       cell_voltages[i][10]);
-    //
-    //     LOG_println(tmp_msg, strlen(tmp_msg));
-    // }
+    for (int i = 0; i < TOTAL_IC; i++) {
+        sprintf(temp_msg, "v%d,%3d,%u,%u,%u,%u,"
+                         "%u,%u,%u,%u,"
+                         "%u,%u",
+                          i,
+                          error,
+                          cell_voltages[i][0],
+                          cell_voltages[i][1],
+                          cell_voltages[i][2],
+                          cell_voltages[i][3],
+                          cell_voltages[i][4],
+                          cell_voltages[i][6],
+                          cell_voltages[i][7],
+                          cell_voltages[i][8],
+                          cell_voltages[i][9],
+                          cell_voltages[i][10]);
+
+        LOG_println(temp_msg, strlen(temp_msg));
+    }
 
     return error;
 }
@@ -234,33 +234,32 @@ uint8_t read_all_temperatures(void)
     mux_disable(TOTAL_IC, MUX1_ADDR);
     _delay_us(10);
 
-    // char temp_msg[6*sizeof(char)+8] = "";
-    // for(int ic = 0; ic < TOTAL_IC; ic++) {
-    //     sprintf(temp_msg, "t%d,%3d,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u", ic, error,
-    //                     temp_sensor_voltages[ic][0],
-    //                     temp_sensor_voltages[ic][1],
-    //                     temp_sensor_voltages[ic][2],
-    //                     temp_sensor_voltages[ic][3],
-    //                     temp_sensor_voltages[ic][4],
-    //                     temp_sensor_voltages[ic][5],
-    //                     temp_sensor_voltages[ic][6],
-    //                     temp_sensor_voltages[ic][7],
-    //                     temp_sensor_voltages[ic][8],
-    //                     temp_sensor_voltages[ic][9],
-    //                     temp_sensor_voltages[ic][10],
-    //                     temp_sensor_voltages[ic][11],
-    //                     temp_sensor_voltages[ic][12],
-    //                     temp_sensor_voltages[ic][13],
-    //                     temp_sensor_voltages[ic][14],
-    //                     temp_sensor_voltages[ic][15],
-    //                     temp_sensor_voltages[ic][16],
-    //                     temp_sensor_voltages[ic][17],
-    //                     temp_sensor_voltages[ic][18],
-    //                     temp_sensor_voltages[ic][19]
-    //                     );
-    //
-    //     LOG_println(temp_msg, strlen(temp_msg));
-    // }
+    for(int ic = 0; ic < TOTAL_IC; ic++) {
+        sprintf(temp_msg, "t%d,%3d,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u", ic, error,
+                        temp_sensor_voltages[ic][0],
+                        temp_sensor_voltages[ic][1],
+                        temp_sensor_voltages[ic][2],
+                        temp_sensor_voltages[ic][3],
+                        temp_sensor_voltages[ic][4],
+                        temp_sensor_voltages[ic][5],
+                        temp_sensor_voltages[ic][6],
+                        temp_sensor_voltages[ic][7],
+                        temp_sensor_voltages[ic][8],
+                        temp_sensor_voltages[ic][9],
+                        temp_sensor_voltages[ic][10],
+                        temp_sensor_voltages[ic][11],
+                        temp_sensor_voltages[ic][12],
+                        temp_sensor_voltages[ic][13],
+                        temp_sensor_voltages[ic][14],
+                        temp_sensor_voltages[ic][15],
+                        temp_sensor_voltages[ic][16],
+                        temp_sensor_voltages[ic][17],
+                        temp_sensor_voltages[ic][18],
+                        temp_sensor_voltages[ic][19]
+                        );
+
+        LOG_println(temp_msg, strlen(temp_msg));
+    }
 
     if (error == 0) {
         // Check temperature values for in-range ness

--- a/boards/BMS/bms.c
+++ b/boards/BMS/bms.c
@@ -209,9 +209,11 @@ uint8_t read_all_temperatures(void)
         }
     }
 
+    mux_disable(TOTAL_IC, MUX1_ADDR);
+
     for( int ic = 0; ic < TOTAL_IC; ic++) {
         char temp_msg[128] = "";
-        sprintf(temp_msg, "t%d,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u", ic, error,
+        sprintf(temp_msg, "t%d,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u", ic, error,
                         temp_sensor_voltages[ic][0],
                         temp_sensor_voltages[ic][1],
                         temp_sensor_voltages[ic][2],

--- a/boards/BMS/bms.c
+++ b/boards/BMS/bms.c
@@ -25,6 +25,10 @@
 #define RELAY_PORT  PORTC
 #define RELAY_DDR   DDRC
 
+#define EXT_LED1_PIN    PB3
+#define EXT_LED2_PIN    PB4
+#define EXT_LED_PORT    PORTB
+
 // gFlag register pre-defines
 #define TRANSMIT_STATUS     0b00000001
 #define UNDER_VOLTAGE       0b00000010
@@ -71,6 +75,9 @@ ISR(TIMER0_COMPA_vect) {
 
         gFlag |= TRANSMIT_STATUS;
         LED_PORT ^= _BV(LED1_PIN);
+
+        // Set EXT LED1 high for start of cycle
+        EXT_LED_PORT |= _BV(EXT_LED1_PIN);
 
     } else {
         gCounterTransmit++;
@@ -288,7 +295,8 @@ int main (void) {
 
     /* Set the data direction register so the led pin is output */
     LED_DDR |= _BV(LED1_PIN) | _BV(LED2_PIN) | _BV(LED3_PIN);
-
+    DDRB |= _BV(EXT_LED1_PIN) | _BV(EXT_LED2_PIN);
+    
     sei();
     /* Initialize CAN */
     CAN_init(CAN_ENABLED);
@@ -310,6 +318,7 @@ int main (void) {
         RELAY_PORT |= _BV(RELAY_PIN);
         gBMSStatus = 0xFF;
         LED_PORT |= _BV(LED3_PIN);
+        EXT_LED_PORT |= _BV(EXT_LED2_PIN);
     }
 
     while (1) {
@@ -330,6 +339,7 @@ int main (void) {
             }
 
             LED_PORT ^= _BV(LED2_PIN);
+            EXT_LED_PORT &= ~_BV(EXT_LED1_PIN);
 
             // Actually build up a CAN message
             //Report relay status
@@ -358,6 +368,7 @@ int main (void) {
             RELAY_PORT &= ~_BV(RELAY_PIN);
             gBMSStatus = 0x00;
             LED_PORT &= ~_BV(LED3_PIN);
+            EXT_LED_PORT &= ~_BV(EXT_LED2_PIN);
         }
 
     }

--- a/boards/BMS/bms.c
+++ b/boards/BMS/bms.c
@@ -109,6 +109,8 @@ uint8_t read_all_voltages(void) // Start Cell ADC Measurement
 
     if (error == 0) {
         // Do value checking
+        gFlag &= ~(OVER_VOLTAGE | UNDER_VOLTAGE);
+
         for (uint8_t ic = 0; ic < TOTAL_IC; ic++) {
             for (uint8_t cell = 0; cell < NUM_CELLS; cell++) {
 
@@ -119,10 +121,9 @@ uint8_t read_all_voltages(void) // Start Cell ADC Measurement
 
                 if (cell_value > OV_THRESHOLD) {
                     gFlag |= OVER_VOLTAGE;
-                } else if (cell_value < UV_THRESHOLD) {
+                }
+                if (cell_value < UV_THRESHOLD) {
                     gFlag |= UNDER_VOLTAGE;
-                } else {
-                    gFlag &= ~(OVER_VOLTAGE | UNDER_VOLTAGE);
                 }
             }
         }
@@ -130,26 +131,26 @@ uint8_t read_all_voltages(void) // Start Cell ADC Measurement
 
     // TODO very slow, comment out after inspection ****************************
     // UART out cell voltages as 10  16-bit ints
-    for (int i = 0; i < TOTAL_IC; i++) {
-        char tmp_msg[116] = "";
-        sprintf(tmp_msg, "v%d,%3d,%u,%u,%u,%u,"
-                         "%u,%u,%u,%u,"
-                         "%u,%u",
-                          i,
-                          error,
-                          cell_voltages[i][0],
-                          cell_voltages[i][1],
-                          cell_voltages[i][2],
-                          cell_voltages[i][3],
-                          cell_voltages[i][4],
-                          cell_voltages[i][6],
-                          cell_voltages[i][7],
-                          cell_voltages[i][8],
-                          cell_voltages[i][9],
-                          cell_voltages[i][10]);
-
-        LOG_println(tmp_msg, strlen(tmp_msg));
-    }
+    // char tmp_msg[1+4+4+6*10] = "";
+    // for (int i = 0; i < TOTAL_IC; i++) {
+    //     sprintf(tmp_msg, "v%d,%3d,%u,%u,%u,%u,"
+    //                      "%u,%u,%u,%u,"
+    //                      "%u,%u",
+    //                       i,
+    //                       error,
+    //                       cell_voltages[i][0],
+    //                       cell_voltages[i][1],
+    //                       cell_voltages[i][2],
+    //                       cell_voltages[i][3],
+    //                       cell_voltages[i][4],
+    //                       cell_voltages[i][6],
+    //                       cell_voltages[i][7],
+    //                       cell_voltages[i][8],
+    //                       cell_voltages[i][9],
+    //                       cell_voltages[i][10]);
+    //
+    //     LOG_println(tmp_msg, strlen(tmp_msg));
+    // }
 
     return error;
 }
@@ -194,6 +195,7 @@ uint8_t read_all_temperatures(void)
 
     // Disable MUX3, now iterate through MUX2 (for modules 3-6)
     mux_disable(TOTAL_IC, MUX3_ADDR);
+    _delay_us(10);
 
     for (uint8_t i = 0; i < MUX_CHANNELS; i++) {
 
@@ -212,6 +214,7 @@ uint8_t read_all_temperatures(void)
     }
     // Disable MUX2, now iterate through MUX1 (for modules 7-10)
     mux_disable(TOTAL_IC, MUX2_ADDR);
+    _delay_us(10);
 
     for (uint8_t i = 0; i < MUX_CHANNELS; i++) {
 
@@ -229,50 +232,51 @@ uint8_t read_all_temperatures(void)
     }
 
     mux_disable(TOTAL_IC, MUX1_ADDR);
+    _delay_us(10);
 
-    for(int ic = 0; ic < TOTAL_IC; ic++) {
-        char temp_msg[196] = "";
-        sprintf(temp_msg, "t%d,%3d,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u", ic, error,
-                        temp_sensor_voltages[ic][0],
-                        temp_sensor_voltages[ic][1],
-                        temp_sensor_voltages[ic][2],
-                        temp_sensor_voltages[ic][3],
-                        temp_sensor_voltages[ic][4],
-                        temp_sensor_voltages[ic][5],
-                        temp_sensor_voltages[ic][6],
-                        temp_sensor_voltages[ic][7],
-                        temp_sensor_voltages[ic][8],
-                        temp_sensor_voltages[ic][9],
-                        temp_sensor_voltages[ic][10],
-                        temp_sensor_voltages[ic][11],
-                        temp_sensor_voltages[ic][12],
-                        temp_sensor_voltages[ic][13],
-                        temp_sensor_voltages[ic][14],
-                        temp_sensor_voltages[ic][15],
-                        temp_sensor_voltages[ic][16],
-                        temp_sensor_voltages[ic][17],
-                        temp_sensor_voltages[ic][18],
-                        temp_sensor_voltages[ic][19]
-                        );
+    // char temp_msg[6*sizeof(char)+8] = "";
+    // for(int ic = 0; ic < TOTAL_IC; ic++) {
+    //     sprintf(temp_msg, "t%d,%3d,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u,%5u", ic, error,
+    //                     temp_sensor_voltages[ic][0],
+    //                     temp_sensor_voltages[ic][1],
+    //                     temp_sensor_voltages[ic][2],
+    //                     temp_sensor_voltages[ic][3],
+    //                     temp_sensor_voltages[ic][4],
+    //                     temp_sensor_voltages[ic][5],
+    //                     temp_sensor_voltages[ic][6],
+    //                     temp_sensor_voltages[ic][7],
+    //                     temp_sensor_voltages[ic][8],
+    //                     temp_sensor_voltages[ic][9],
+    //                     temp_sensor_voltages[ic][10],
+    //                     temp_sensor_voltages[ic][11],
+    //                     temp_sensor_voltages[ic][12],
+    //                     temp_sensor_voltages[ic][13],
+    //                     temp_sensor_voltages[ic][14],
+    //                     temp_sensor_voltages[ic][15],
+    //                     temp_sensor_voltages[ic][16],
+    //                     temp_sensor_voltages[ic][17],
+    //                     temp_sensor_voltages[ic][18],
+    //                     temp_sensor_voltages[ic][19]
+    //                     );
+    //
+    //     LOG_println(temp_msg, strlen(temp_msg));
+    // }
 
-        LOG_println(temp_msg, strlen(temp_msg));
-    }
+    if (error == 0) {
+        // Check temperature values for in-range ness
+        gFlag &= ~(OVER_TEMP | SOFT_OVER_TEMP | UNDER_TEMP);
 
-    // Check temperature values for in-range ness
-    gFlag &= ~(OVER_TEMP | SOFT_OVER_TEMP | UNDER_TEMP);
-    LED_PORT &= ~_BV(LED3_PIN);
-
-    for (uint8_t ic = 0; ic < TOTAL_IC; ic ++) {
-        for (uint8_t sensor = 0; sensor < NUM_TEMPS; sensor ++) {
-            if (temp_sensor_voltages[ic][sensor] < SOFT_OT_THRESHOLD) {
-                gFlag |= SOFT_OVER_TEMP;
-                LED_PORT |= _BV(LED3_PIN);
-            }
-            if (temp_sensor_voltages[ic][sensor] < OT_THRESHOLD) {
-                gFlag |= OVER_TEMP;
-            }
-            if (temp_sensor_voltages[ic][sensor] > UT_THRESHOLD) {
-                gFlag |= UNDER_TEMP;
+        for (uint8_t ic = 0; ic < TOTAL_IC; ic ++) {
+            for (uint8_t sensor = 0; sensor < NUM_TEMPS; sensor ++) {
+                if (temp_sensor_voltages[ic][sensor] < SOFT_OT_THRESHOLD) {
+                    gFlag |= SOFT_OVER_TEMP;
+                }
+                if (temp_sensor_voltages[ic][sensor] < OT_THRESHOLD) {
+                    gFlag |= OVER_TEMP;
+                }
+                if (temp_sensor_voltages[ic][sensor] > UT_THRESHOLD) {
+                    gFlag |= UNDER_TEMP;
+                }
             }
         }
     }
@@ -306,6 +310,7 @@ int main (void) {
     if (!(gFlag & (OVER_TEMP | UNDER_TEMP | OVER_VOLTAGE | UNDER_VOLTAGE))) {
         RELAY_PORT |= _BV(RELAY_PIN);
         gBMSStatus = 0xFF;
+        LED_PORT |= _BV(LED3_PIN);
     }
 
     while (1) {
@@ -353,6 +358,7 @@ int main (void) {
 
             RELAY_PORT &= ~_BV(RELAY_PIN);
             gBMSStatus = 0x00;
+            LED_PORT &= ~_BV(LED3_PIN);
         }
 
     }

--- a/boards/BMS/bms.c
+++ b/boards/BMS/bms.c
@@ -162,7 +162,7 @@ uint8_t read_all_temperatures(void)
         mux_set_channel(TOTAL_IC, MUX3_ADDR, i);
         _delay_us(5);                             //Spec is 1600ns from stop cond.
         ltc6811_adax(MD_7KHZ_3KHZ, AUX_CH_GPIO1); //start ADC measurement for GPIO CH 1
-        _delay_us(500);                           //only need to delay 500uS for GPIO1 conversion
+        ltc6811_pollAdc();
         error = ltc6811_rdaux(0,TOTAL_IC, _aux_voltages); //Parse all ADC measurements back
 
         // Grab aux voltages into the temp voltages array
@@ -170,6 +170,7 @@ uint8_t read_all_temperatures(void)
             //First four are out of order, 0123 are 2_2, 2_1, 1_2, and 1_1 respectively
             temp_sensor_voltages[ic][3-i] = _aux_voltages[ic][0]; //Store temperatures
         }
+
     }
 
     // Disable MUX3, now iterate through MUX2 (for modules 3-6)
@@ -180,13 +181,13 @@ uint8_t read_all_temperatures(void)
         mux_set_channel(TOTAL_IC, MUX2_ADDR, i);
         _delay_us(5);                             //Spec is 1600ns from stop cond.
         ltc6811_adax(MD_7KHZ_3KHZ, AUX_CH_GPIO1); //start ADC measurement for GPIO CH 1
-        _delay_us(500);                           //only need to delay 500uS for GPIO1 conversion
+        ltc6811_pollAdc();//only need to delay 500uS for GPIO1 conversion
         error = ltc6811_rdaux(0, TOTAL_IC, _aux_voltages); //Parse all ADC measurements back
 
         // Grab aux voltages into the temp voltages array
         for (uint8_t ic = 0; ic < TOTAL_IC; ic++) {
             //Sensors are in reverse order
-            temp_sensor_voltages[ic][MUX_CHANNELS-1-i] = _aux_voltages[ic][0]; //Store temperatures
+            temp_sensor_voltages[ic][NUM_TEMPS-9-i] = _aux_voltages[ic][0]; //Store temperatures
         }
     }
 
@@ -198,19 +199,19 @@ uint8_t read_all_temperatures(void)
         mux_set_channel(TOTAL_IC, MUX1_ADDR, i);
         _delay_us(5);                             //Spec is 1600ns from stop cond.
         ltc6811_adax(MD_7KHZ_3KHZ, AUX_CH_GPIO1); //start ADC measurement for GPIO CH 1
-        _delay_us(500);                           //only need to delay 500uS for GPIO1 conversion
+        ltc6811_pollAdc();                           //only need to delay 500uS for GPIO1 conversion
         error = ltc6811_rdaux(0, TOTAL_IC, _aux_voltages); //Parse all ADC measurements back
 
         // Grab aux voltages into the temp voltages array
         for (uint8_t ic = 0; ic < TOTAL_IC; ic++) {
             //Sensors are in reverse order, 0123 are 2_2, 2_1, 1_2, and 1_1 respectively
-            temp_sensor_voltages[ic][MUX_CHANNELS-1-i] = _aux_voltages[ic][0]; //Store temperatures
+            temp_sensor_voltages[ic][NUM_TEMPS-1-i] = _aux_voltages[ic][0]; //Store temperatures
         }
     }
 
     for( int ic = 0; ic < TOTAL_IC; ic++) {
         char temp_msg[128] = "";
-        sprintf(temp_msg, "t%d,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u", ic, error,
+        sprintf(temp_msg, "t%d,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u", ic, error,
                         temp_sensor_voltages[ic][0],
                         temp_sensor_voltages[ic][1],
                         temp_sensor_voltages[ic][2],
@@ -220,7 +221,17 @@ uint8_t read_all_temperatures(void)
                         temp_sensor_voltages[ic][6],
                         temp_sensor_voltages[ic][7],
                         temp_sensor_voltages[ic][8],
-                        temp_sensor_voltages[ic][9]
+                        temp_sensor_voltages[ic][9],
+                        temp_sensor_voltages[ic][10],
+                        temp_sensor_voltages[ic][11],
+                        temp_sensor_voltages[ic][12],
+                        temp_sensor_voltages[ic][13],
+                        temp_sensor_voltages[ic][14],
+                        temp_sensor_voltages[ic][15],
+                        temp_sensor_voltages[ic][16],
+                        temp_sensor_voltages[ic][17],
+                        temp_sensor_voltages[ic][18],
+                        temp_sensor_voltages[ic][19]
                         );
 
         LOG_println(temp_msg, strlen(temp_msg));
@@ -269,7 +280,7 @@ int main (void) {
             gFlag &= ~TRANSMIT_STATUS;
 
             uint8_t error = 0;
-            error += read_all_voltages();
+            // error += read_all_voltages();
             error += read_all_temperatures();
 
             // If we got a PEC error from any of those

--- a/boards/BMS/ltc6811.c
+++ b/boards/BMS/ltc6811.c
@@ -72,7 +72,10 @@ void ltc6811_adcv(
     SPI_start();
     uint8_t null;
     SPI_write_then_read(cmd, 4, &null, 0);
+
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
     SPI_end();
+    _delay_us(4);
 }
 
 // THIS FUNCTION DOES NOT WORK ON LTC6804 *************************************
@@ -88,7 +91,7 @@ uint32_t ltc6811_pollAdc(void)
 
     cmd[0] = 0x07;
     cmd[1] = 0x14;
-    cmd_pec = pec15_calc(2, cmd); //TODO: what is pec15_calc?
+    cmd_pec = pec15_calc(2, cmd);
     cmd[2] = (uint8_t)(cmd_pec >> 8);
     cmd[3] = (uint8_t)(cmd_pec);
 
@@ -111,7 +114,9 @@ uint32_t ltc6811_pollAdc(void)
         }
     }
 
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
     SPI_end();
+    _delay_us(4);
 
     return counter;
 }
@@ -229,7 +234,10 @@ void _ltc6811_rdcv_reg(uint8_t reg, //Determines which cell voltage register is 
 
     SPI_start();
     SPI_write_then_read(cmd, 4, data, (REG_LEN * total_ic));
+
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
     SPI_end();
+    _delay_us(4);
 }
 
 //Start a GPIO and Vref2 Conversion
@@ -256,7 +264,10 @@ void ltc6811_adax(
     SPI_start();
     uint8_t null;
     SPI_write_then_read(cmd, 4, &null, 0);
+
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
     SPI_end();
+    _delay_us(4);
 }
 
 /*
@@ -381,7 +392,10 @@ void _ltc6811_rdaux_reg(uint8_t reg, //Determines which GPIO voltage register is
 
     SPI_start(); //set CS low
     SPI_write_then_read(cmd,4,data,(REG_LEN*total_ic));
-    SPI_end(); //set CS high
+
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
+    SPI_end();
+    _delay_us(4);
 }
 
 /*
@@ -426,7 +440,10 @@ void wrcomm(uint8_t total_ic, //The number of ICs being written to
     SPI_start();
     uint8_t null;
     SPI_write_then_read(cmd, CMD_LEN, &null, 0);
+
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
     SPI_end();
+    _delay_us(4);
 }
 
 /*
@@ -455,7 +472,9 @@ void stcomm(void)
         SPI_transfer(0xFF, &null[0]);
     }
 
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
     SPI_end();
+    _delay_us(4);
 }
 
 /*
@@ -484,7 +503,10 @@ int8_t rdcomm(uint8_t total_ic, //Number of ICs in the system
     //wakeup_idle (); //This will guarantee that the ltc6811 isoSPI port is awake. This command can be removed.
     SPI_start();
     SPI_write_then_read(cmd, 4, rx_data, (BYTES_IN_REG*total_ic));         //Read the configuration data of all ICs on the daisy chain into
-    SPI_end(); //set CS high
+
+    _delay_us(4); //For up to 15 boards in series. See pg 69 in the ltc6804 datasheet.
+    SPI_end();
+    _delay_us(4);
 
     for (uint8_t current_ic = 0; current_ic < total_ic; current_ic++)       //executes for each ltc6811 in the daisy chain and packs the data
     {

--- a/boards/BMS/ltc6811.c
+++ b/boards/BMS/ltc6811.c
@@ -417,7 +417,7 @@ void wrcomm(uint8_t total_ic, //The number of ICs being written to
 
     SPI_start();
     uint8_t null;
-    SPI_write_then_read(cmd, 4, &null, 0);
+    SPI_write_then_read(cmd, CMD_LEN, &null, 0);
     SPI_end();
 }
 

--- a/boards/BMS/ltc6811.c
+++ b/boards/BMS/ltc6811.c
@@ -35,9 +35,17 @@ void ltc6811_init(volatile uint8_t* cs_port, uint8_t cs_pin) {
 
 //Generic wakeup command to wake the ltc6813 from sleep
 void wakeup_sleep(uint8_t total_ic) {
-    for (int i =0; i<TOTAL_IC+1; i++) {
+    for (int i =0; i<total_ic+1; i++) {
         SPI_start(); // chip select
         _delay_us(300); // Guarantees the ltc6813 will be in standby
+        SPI_end();
+    }
+}
+
+void wakeup_idle(uint8_t total_ic) {
+    for (int i =0; i<total_ic+1; i++) {
+        SPI_start();
+        _delay_us(2); //Guarantees the isoSPI will be in ready mode
         SPI_end();
     }
 }

--- a/boards/BMS/ltc6811.h
+++ b/boards/BMS/ltc6811.h
@@ -20,7 +20,7 @@
 
 #define TOTAL_IC    1
 #define NUM_CELLS   12 //There are 10, but we need to read all 12 back.
-#define NUM_TEMPS   10 //There are 10 of these.
+#define NUM_TEMPS   20  //There are 20 temp sensors per segment
 #define NUM_AUX_CH  6   // There are 10 AUX voltages
 
 // Cell voltages read back from the peripheral board

--- a/boards/BMS/ltc6811.h
+++ b/boards/BMS/ltc6811.h
@@ -49,6 +49,8 @@ void SPI_write_then_read(uint8_t *tx_data, uint8_t tx_len, uint8_t* rx_data, uin
 //Generic wakeup command to wake the ltc6813 from sleep
 void wakeup_sleep(uint8_t total_ic);
 
+void wakeup_idle(uint8_t total_ic);
+
 void ltc6811_adcv(
         uint8_t MD, //ADC Mode
         uint8_t DCP, //Discharge Permit

--- a/boards/BMS/ltc6811.h
+++ b/boards/BMS/ltc6811.h
@@ -18,7 +18,7 @@
 #include "spi.h"
 #include "ltc6811_defs.h"
 
-#define TOTAL_IC    1
+#define TOTAL_IC    7
 #define NUM_CELLS   12 //There are 10, but we need to read all 12 back.
 #define NUM_TEMPS   20  //There are 20 temp sensors per segment
 #define NUM_AUX_CH  6   // There are 10 AUX voltages


### PR DESCRIPTION
Includes all the final fixes for BMS 2019 code. 
- PEC error handling
- Refactoring of all isoSPI communications functions with new OEM SPI library
- Corrected pollADC (which works on a 6804 despite LTC saying it won't)
- Transmitting BMS CAN
- Fixing UART buffer allocation that was causing an out-of-memory error on longer strings (RIP this still kills me how much time it wasted, thanks Manu)
- Transmits out UART messages for inspection
- Sets RJ45 LEDs to show BMS status output and measurement cycle timing.